### PR TITLE
Updated Step 4: Manage the Container

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Solace CLI management access:
 1. Enter the following docker exec command to access the Solace CLI on the primary message broker:
 
 ```
-> docker exec -it primary cli
+> docker exec -it primary /usr/sw/loads/currentload/bin/cli -A
 ```
 2. Enter the following commands to enter configuration mode:
 ```


### PR DESCRIPTION
@mdspielman It was found that the new command, `docker exec -it $containerName cli` has some bugs and won't be fixed anytime soon. Reverting back to the old command,  `docker exec -it $containerName /usr/sw/loads/currentload/bin/cli -A`. Thanks again!