### PR TITLE
port for semp(tls) changed from 943 to 1943.

### DIFF
--- a/template/PubSub_Standard_HA.YML
+++ b/template/PubSub_Standard_HA.YML
@@ -42,6 +42,7 @@ services:
       configsync_enable: "yes"
       redundancy_matelink_connectvia: backup
       redundancy_activestandbyrole: primary
+      service_semp_tlsport: 1943
     << : *default-common
 
   backup:
@@ -55,6 +56,7 @@ services:
       configsync_enable: "yes"
       redundancy_matelink_connectvia: primary
       redundancy_activestandbyrole: backup
+      service_semp_tlsport: 1943
     << : *default-common
 
   monitoring:
@@ -66,6 +68,7 @@ services:
       << : *default-environment
       routername: monitoring
       nodetype: monitoring
+      service_semp_tlsport: 1943
     << : *default-common
 
   lb:
@@ -83,7 +86,7 @@ services:
     ports:
       - '80:80'
       - '443:443'
-      - '943:943'
+      - '1943:1943'
       - '1883:1883'
       - '5671:5671'
       - '5672:5672'

--- a/template/assertMaster.perl
+++ b/template/assertMaster.perl
@@ -130,7 +130,7 @@ print $fh $frontEndConfig;
 print $fh "  server $primaryName $primaryName:8080 check port 5550\n";
 print $fh "  server $backupName $backupName:8080 check port 5550\n\n";
 
-addHaProxyListen($fh, 'semp_tls_in',       943);
+addHaProxyListen($fh, 'semp_tls_in',       1943);
 addHaProxyListen($fh, 'smf_in',            55555);
 addHaProxyListen($fh, 'smf_compressed_in', 55003);
 addHaProxyListen($fh, 'smf_tls_in',        55443);


### PR DESCRIPTION
This is needed for openshift_scc2, where ports below 1024 is not allowed. So for semp(ssl) the port has been changed from default 943 to 1943.