### PR TITLE
Update to use PSK instead of redundancy group password

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ The Docker Compose template allows you to get an HA group up-and-running using a
 ![](images/LoadBalancer_HATriplet.png)
 
 The template contains the following two files:
-* _PubSub_standard_HA.yml_ — The docker-compose script that creates the containers for the primary, backup, and monitoring nodes as well as a container for the load balancer. The script also contains configuration keys for setting up redundancy, which automatically get the HA group up-and-running.
+* _PubSub_Standard_HA.yml_ — The docker-compose script that creates the containers for the primary, backup, and monitoring nodes as well as a container for the load balancer. The script also contains configuration keys for setting up redundancy, which automatically get the HA group up-and-running.
 * _assertMaster.perl_ — A Perl script that creates the HAProxy load balancer configuration file, which is mapped to the load balancer container. Once the containers are created, the load balancer automatically executes the _Assert master admin operation_, which ensures that the configuration of the primary and backup message brokers are synchronized. For more information, refer to [Solace PubSub+ documentation - Asserting Message Broker System Configurations](https://docs.solace.com/Configuring-and-Managing-Routers/Using-Config-Sync.htm#Assertin).
+Note: If using a version older than 9.2, the docker-compose script PubSub_Standard_HA_Pre_9_2.YML should be used instead of PubSub_Standard_HA.YML. This docker-compose script uses redundancy group password instead of a pre-shared authentication key. Pre-shared authentication keys are highly recommended when using versions 9.2 and above.
 <br><br>
 <a name="download-template"></a>
 ## Step 1: Download Docker Compose Template

--- a/template/PubSub_Standard_HA_Pre_9_2.YML
+++ b/template/PubSub_Standard_HA_Pre_9_2.YML
@@ -1,4 +1,4 @@
-# This file is for broker versions 9.2 and above
+# This file is for broker versions before 9.2
 version: '2.1'
 
 networks:
@@ -10,7 +10,7 @@ x-environment:
   username_admin_password: ${ADMIN_PASSWORD:-admin}
   system_scaling_maxconnectioncount: 100
   redundancy_enable: "yes"
-  redundancy_authentication_presharedkey_key: 'JM2gWU1wU9563gzDYjO3jFA9UJO9QhYVN7SAOFqfGAk='
+  redundancy_group_password: topsecret
   redundancy_group_node_primary_connectvia: primary
   redundancy_group_node_primary_nodetype: message_routing
   redundancy_group_node_backup_connectvia: backup


### PR DESCRIPTION
Change the docker-compose script to use PSK instead of redundancy group password. Add a copy of the old docker-compose script for use with versions before 9.2. Update README.md to include a note about the difference between these two files.