### PR TITLE
Add assert-leader

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ The Docker Compose template allows you to get an HA group up-and-running using a
 ![](images/LoadBalancer_HATriplet.png)
 
 The template contains the following two files:
-* _PubSub_standard_HA.yml_ — The docker-compose script that creates the containers for the primary, backup, and monitoring nodes as well as a container for the load balancer. The script also contains configuration keys for setting up redundancy, which automatically get the HA group up-and-running.
+* _PubSub_Standard_HA.yml_ — The docker-compose script that creates the containers for the primary, backup, and monitoring nodes as well as a container for the load balancer. The script also contains configuration keys for setting up redundancy, which automatically get the HA group up-and-running.
 * _assertMaster.perl_ — A Perl script that creates the HAProxy load balancer configuration file, which is mapped to the load balancer container. Once the containers are created, the load balancer automatically executes the _Assert master admin operation_, which ensures that the configuration of the primary and backup message brokers are synchronized. For more information, refer to [Solace PubSub+ documentation - Asserting Message Broker System Configurations](https://docs.solace.com/Configuring-and-Managing-Routers/Using-Config-Sync.htm#Assertin).
+Note: If using a version older than 9.2, the docker-compose script PubSub_Standard_HA_Pre_9_2.YML should be used instead of PubSub_Standard_HA.YML. This docker-compose script uses redundancy group password instead of a pre-shared authentication key. Pre-shared authentication keys are highly recommended when using versions 9.2 and above.
 <br><br>
 <a name="download-template"></a>
 ## Step 1: Download Docker Compose Template

--- a/template/PubSub_Standard_HA.YML
+++ b/template/PubSub_Standard_HA.YML
@@ -2,7 +2,7 @@ version: '2.1'
 
 networks:
   hanet: {}
-  
+
 x-environment:
   &default-environment
   username_admin_globalaccesslevel: admin
@@ -16,7 +16,7 @@ x-environment:
   redundancy_group_node_backup_nodetype: message_routing
   redundancy_group_node_monitoring_connectvia: monitoring
   redundancy_group_node_monitoring_nodetype: monitoring
-  
+
 x-common:
   &default-common
   image: solace/solace-pubsub-standard:${TAG:-latest}
@@ -38,7 +38,7 @@ services:
       - "212:2222"
     volumes:
       - storage-group-1:/var/lib/solace
-    environment: 
+    environment:
       << : *default-environment
       routername: primary
       configsync_enable: "yes"
@@ -82,14 +82,14 @@ services:
     image: 'haproxy:latest'
     user: 0:0
     volumes:
-      - ./assertMaster.perl:/assertMaster.perl
+      - ./assertLeader.perl:/assertLeader.perl
     environment:
       ADMIN_USERNAME: admin
       ADMIN_PASSWORD: ${ADMIN_PASSWORD:-admin}
     entrypoint:
       - /bin/bash
       - "-c"
-      - "perl /assertMaster.perl"
+      - "perl /assertLeader.perl"
     ports:
       - '8008:8008'
       - '1443:1443'

--- a/template/PubSub_Standard_HA_Pre_9_2.YML
+++ b/template/PubSub_Standard_HA_Pre_9_2.YML
@@ -83,7 +83,7 @@ services:
     image: 'haproxy:latest'
     user: 0:0
     volumes:
-      - ./assertMaster.perl:/assertMaster.perl
+      - ./assertLeader.perl:/assertLeader.perl
     environment:
       ADMIN_USERNAME: admin
       ADMIN_PASSWORD: ${ADMIN_PASSWORD:-admin}

--- a/template/PubSub_Standard_HA_Pre_9_2.YML
+++ b/template/PubSub_Standard_HA_Pre_9_2.YML
@@ -1,4 +1,4 @@
-# This file is for broker versions 9.2 and above
+# This file is for broker versions before 9.2
 version: '2.1'
 
 networks:
@@ -10,7 +10,7 @@ x-environment:
   username_admin_password: ${ADMIN_PASSWORD:-admin}
   system_scaling_maxconnectioncount: 100
   redundancy_enable: "yes"
-  redundancy_authentication_presharedkey_key: 'JM2gWU1wU9563gzDYjO3jFA9UJO9QhYVN7SAOFqfGAk='
+  redundancy_group_password: topsecret
   redundancy_group_node_primary_connectvia: primary
   redundancy_group_node_primary_nodetype: message_routing
   redundancy_group_node_backup_connectvia: backup


### PR DESCRIPTION
Addresses issues 9 and 11. 
- Update `PubSub_Standard_HA.YML` to use PSK instead of redundancy group passwords
- Add `PubSub_Standard_HA_Pre_9_2.YML` for deploying versions before 9.2
- Rename `assertMaster.perl` to `assertLeader.perl`
- Add assert-leader command for message-vpn
- Add check for SEMP execute-result code when sending SEMP requests in `assertLeader.perl`